### PR TITLE
Fix reducing stars for correct person

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -118,7 +118,7 @@ $(function() {
       const undoIcon = $('<i></i>', {class: 'fas fa-undo-alt fa-lg undo-icon'});
       undoIcon.appendTo(undoButton);
       undoButton.click(function() {
-        $('.star')
+        starsContainer.find('.star')
           .first()
           .remove();
         scoreObj.score -= 1;


### PR DESCRIPTION
This fixes the bug where clicking an Undo button reduces a star for the first person on the list, not the person associated with the Undo button.